### PR TITLE
meetups: Meetups are now scoped to threads

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       HTTP_PORT: 5000
     networks:
       - nginx-proxy
+    restart: always
 
 networks:
   nginx-proxy:

--- a/backend/src/commands/meetup/commands/cancel.ts
+++ b/backend/src/commands/meetup/commands/cancel.ts
@@ -1,6 +1,5 @@
 import { Message, MessageEmbed } from 'discord.js';
 import { DateTime } from 'luxon';
-import MultiChoice from '@sjbha/utils/multi-choice';
 
 import * as db from '../db/meetups';
 import * as M from '../common/Meetup';
@@ -8,47 +7,31 @@ import * as M from '../common/Meetup';
 /**
  * Cancel a meetup
  */
- export async function cancel (message: Message) : Promise<void> {
-  const userMeetups = await db.find ({
-    state:       { type: 'Live' },
-    organizerID: message.author.id
-  });
-  
-  // Make sure they have any meetups they can cancel
-  if (!userMeetups.length) {
-    message.reply ('You have no meetups to cancel');
-
+export async function cancel (message: Message) : Promise<void> {
+  if (!message.channel.isThread ()) {
+    message.reply ('To cancel a meetup, use `!meetup cancel <reason>` in the meetup\'s thread');
     return;
   }
 
-  // Pick a meetup they want to cancel
-  // todo: Should add a note that they can transfer responsibility
-  const meetupPicker = MultiChoice.create <db.Meetup> (
-    'Which meetup would you like to cancel?',
-    userMeetups.map (meetup => MultiChoice.opt (meetup.title, meetup))
-  );
+  const [_, __, ...reasonArr] = message.content.split (' ');
+  const reason = reasonArr.join (' ');
 
-  await message.reply (meetupPicker.toString ());
-  const meetup = await  message.channel
-    .createMessageCollector ({ filter: m => m.author.id === message.author.id })
-    .next.then (meetupPicker.parse);
-
-  if (!meetup) 
+  if (!reason) {
+    message.reply ('Please specific a reason for cancellation after the command: `!meetup cancel Some words why this meetup is beign cancelled`');
     return;
+  }
 
-  // Give a reason, which we use to let people know why
-  await message.reply (`What is the reason for cancelling '${meetup.title}'? (Will let the RSVP's know it was cancelled)`)
-  const cancelReason = await message.channel
-    .createMessageCollector ({ filter: m => m.author.id === message.author.id })
-    .next.then (msg => msg.content);
-
-  if (!cancelReason)
+  const meetup = await db.findOne ({ threadID: message.channelId });
+  
+  if (!meetup) {
+    message.reply ('Hm, it doesnt look like this thread is for a meetup');
     return;
+  }
 
   const posting = new MessageEmbed ({
-    title:       '📅  **CANCELLED**: ~~' + meetup.title + '~~',
+    title:       `📅  **CANCELLED**: ~~${meetup.title}~~`,
     color:       '#9b3128',
-    description: `> ${cancelReason}`
+    description: `> ${reason}`
   });
 
   await Promise.all ([
@@ -57,11 +40,12 @@ import * as M from '../common/Meetup';
       ...meetup,
       state: { 
         type:      'Cancelled', 
-        reason:    cancelReason, 
+        reason:    reason, 
         timestamp: DateTime.local ().toISO () 
       }
     })
   ]);
 
-  message.channel.send ({ content: `Cancelled **${meetup.title}**` });
+  await message.channel.send ({ content: 'This meetup has been cancelled' });
+  await message.channel.setArchived (true);
 }

--- a/backend/src/commands/meetup/commands/create.ts
+++ b/backend/src/commands/meetup/commands/create.ts
@@ -50,19 +50,21 @@ export async function create (message: Message) : Promise<void> {
     announcement:    { type: 'Pending', channelId: message.channel.id }
   };
 
-  const [announcement] = await Promise.all ([
-    message.channel.send ({ embeds: [Announcement (meetup, [])] }),
-    message.delete ()
-  ]);
+  const dateShort = DateTime
+    .fromISO (meetup.timestamp)
+    .toFormat ('MMM dd');
 
-  const thread = await announcement.startThread ({
-    name:   `📅 ${meetup.title}`,
-    reason: 'Needed a separate thread for food',
+  const thread = await message.channel.threads.create ({
+    name:   `📅  ${meetup.title} - ${dateShort}`,
+    reason: 'Meetup discussion thread',
     
     autoArchiveDuration: 60,
   });
 
-  await thread.send ('This thread was automatically created for meetup discussion. Ask questions, make plans, and find people in this thread');
+  const [announcement] = await Promise.all ([
+    thread.send ({ embeds: [Announcement (meetup, [])] }),
+    message.delete ()
+  ]);
   
   await db.insert ({
     ...meetup,

--- a/backend/src/commands/meetup/register.ts
+++ b/backend/src/commands/meetup/register.ts
@@ -15,13 +15,27 @@ const labs_category = (env.IS_PRODUCTION)
 
 Message$
   .startsWith ('!meetup')
-  .guildOnly ()
-  .filter (message => message.channel.type === 'GUILD_TEXT' && message.channel.parentId === labs_category)
-  .routes ({ 
-    'create': create, 
-    'cancel': cancel, 
-    'edit':   edit,
-    'empty':  msg => msg.reply (`Use this link to create a meetup: ${env.UI_HOSTNAME}/meetup`)
+  .subscribe (message => {
+    const [, route] = message.content
+      .replace (/\n/g, ' ')
+      .split (' ');
+ 
+    const isGuild = (message.channel.type === 'GUILD_TEXT' && message.channel.parentId === labs_category);
+    const isThread = message.channel.isThread ();
+
+    switch (true) {
+      case (isGuild && route === 'create'):
+        return create (message);
+
+      case (isGuild):
+        return message.reply (`Use this link to create a meetup: ${env.UI_HOSTNAME}/meetup`);
+
+      case (isThread && route === 'edit'):
+        return edit (message);
+
+      case (isThread && route === 'cancel'):
+        return cancel (message);
+    }
   });
 
 

--- a/backend/src/commands/pong/register.ts
+++ b/backend/src/commands/pong/register.ts
@@ -3,3 +3,16 @@ import { Message$ } from '@sjbha/app';
 Message$
   .startsWith ('!pong')
   .replyWith ('Ping?');
+
+Message$.startsWith ('!thread').subscribe (async message => {
+  const channel = message.channel;
+  
+  if (channel.type === 'GUILD_TEXT') {
+    const thread = await channel.threads.create ({
+      name:                'Some Meetup - Oct 2',
+      autoArchiveDuration: 60,
+      reason:              'For the meetup'
+      // startMessage:        message
+    });
+  }
+});

--- a/frontend/src/pages/meetup/CreateMeetup.svelte
+++ b/frontend/src/pages/meetup/CreateMeetup.svelte
@@ -2,7 +2,7 @@
   import Details from './form/Details.svelte';
   import Location from './form/Location.svelte';
   import Links from './form/Links.svelte';
-  import GuestLimit from './form/GenerateCommand.svelte';
+  // import GuestLimit from './form/GenerateCommand.svelte';
   import GenerateCommand from './form/GenerateCommand.svelte';
   import { fetchMeetup, store } from './store';
 
@@ -10,7 +10,7 @@
 
   if (window.location.hash) {
     const id = window.location.hash.substr (1);
-    
+
     fetchMeetup (id)
       .then (_ => { state = 'ready'; })
       .catch (_ => { state = 'could-not-load'; });

--- a/frontend/src/pages/meetup/form/GenerateCommand.svelte
+++ b/frontend/src/pages/meetup/form/GenerateCommand.svelte
@@ -29,7 +29,7 @@
       output.links = validLinks;
 
     return (store.id)
-      ? `!meetup edit\n${YAML.stringify({id: store.id, ...output})}`
+      ? `!meetup edit\n${YAML.stringify(output)}`
       : `!meetup create\n${YAML.stringify(output)}`;
   }
 </script>

--- a/frontend/src/pages/meetup/store.ts
+++ b/frontend/src/pages/meetup/store.ts
@@ -87,9 +87,8 @@ export const errors = derived (state, state$ => {
 export async function fetchMeetup (id: string) : Promise<void> {
   const response = await fetch (`${__HOST__}/meetup/${id}`).then (r => r.json());
 
-  let location: Location | null = null;
   state.set ({
-    id: id,
+    id,
     title: response.title,
     description: response.description,
     date: response.timestamp,


### PR DESCRIPTION
Since archived threads disappear on mobile, I moved the RSVP post to the thread channel so that the directory can link to the post, which'll open the thread on people's devices

Also has a side effect, this means I can scope !meetup edit and !meetup cancel commands to the thread, which is just way easier to use