### PR TITLE
Add note to README regarding running of project on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ In order to run the bot, you will need to create a `.env` file in the root direc
 npm run dev
 ```
 
+note: One may run into the following [error](https://stackoverflow.com/questions/11928013/node-env-is-not-recognized-as-an-internal-or-external-command-operable-comman) when attempting to execute `npm run dev` on Windows:
+```
+"NODE_ENV" is not recognized as an internal or external command, operable command or batch file.
+```
+The above error is due to the fact that the npm script relies on Linux based commands. To resolve this issue, one can install a [Windows Node environment package](https://github.com/laggingreflex/win-node-env) using `npm install -g win-node-env`.
+
 note: run commands via `_help` instead of `!help`. Change the symbol by adding the '--symbol=' switch after 'npm run dev'
 
 Hit up @s3b if you want access to the dev server. Will provide you a .env file with the dev keys


### PR DESCRIPTION
The current command for running the project, `npm run dev`, relies on the `NODE_ENV=development node` command that is used for Linux platforms. By default, Windows machines do not possess the needed module and will present the following error message when the npm script is run:

```
"NODE_ENV" is not recognized as an internal or external command, operable command or batch file.
```

Therefore, a note has been added to the README to indicate how one can install a Windows-dedicated module to resolve the issue.

An alternative solution would be to [modify the `package.json` file to account for all operating systems](https://stackoverflow.com/questions/45082648/npm-package-json-os-specific-script). Given that the current `legacy` branch will eventually be deprecated, it was determined that using the quick-and-easy installation of the Windows-dedicated module would be sufficient for the time being.