### PR TITLE
meetup: lower max description length

### DIFF
--- a/backend/src/commands/meetup/commands/create.ts
+++ b/backend/src/commands/meetup/commands/create.ts
@@ -64,10 +64,18 @@ export async function create (message: Message) : Promise<void> {
     state:           { type: 'Live' }
   };
 
-  const post = await render (message.client, meetup);
+  try {
+    const post = await render (message.client, meetup);
 
-  await db.insert ({ 
-    ...meetup,
-    announcementID: post.id
-  });
+    await db.insert ({ 
+      ...meetup,
+      announcementID: post.id
+    });
+  }
+  catch (e) {
+    const errId = Math.floor (Math.random () * 1000).toString ();
+    console.error ('Failed to create meetup (ERR ' + errId + ')', e);
+    await message.channel.send (`⚠️ Bot broke unexpectedly while trying to post meetup [ID ${errId}]`);
+    await thread.delete ();
+  }
 }

--- a/backend/src/commands/meetup/common/MeetupOptions.ts
+++ b/backend/src/commands/meetup/common/MeetupOptions.ts
@@ -3,7 +3,7 @@ import { object, string, array, pattern, optional, assert, Infer, StructError, t
 import { option } from 'ts-option';
 import * as db from '../db/meetups';
 
-const MAX_DESCRIPTION_SIZE = 1600;
+const MAX_DESCRIPTION_SIZE = 1000;
 
 // eslint-disable-next-line max-len
 const url = pattern (string (), /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/);

--- a/backend/src/commands/meetup/features/RenderAnnouncement.ts
+++ b/backend/src/commands/meetup/features/RenderAnnouncement.ts
@@ -41,7 +41,9 @@ const gcalLink = (meetup: db.Meetup) : string => {
     action:   'TEMPLATE',
     text:     meetup.title,
     dates:    encodeDate (ts) + '/' + encodeDate (ts.plus ({ hour: 2 })),
-    details:  meetup.description,
+    // todo: details can break if the description is long
+    // see: https://github.com/hellos3b/sjbha-bot/issues/135
+    // details:  meetup.description,
     location: option (meetup.location)
       .filter (loc => loc.autoLink)
       .map (loc => loc.value)

--- a/frontend/src/pages/meetup/store.ts
+++ b/frontend/src/pages/meetup/store.ts
@@ -2,7 +2,7 @@ import { DateTime } from 'luxon';
 import { derived, writable } from 'svelte/store';
 import { Option } from 'prelude-ts';
 
-export const MAX_DESCRIPTION_LENGTH = 1200;
+export const MAX_DESCRIPTION_LENGTH = 1000;
 
 export const MAX_LOCATION_COMMENTS_LENGTH = 300;
 


### PR DESCRIPTION
Max embed length is 1024 and the description was set to 1600. Updated it so nobody accidentally hits the limit

Also Removed description from gcal link, see: https://github.com/hellos3b/sjbha-bot/issues/135