### PR TITLE
meetup: auto rsvp creater, update join message

### DIFF
--- a/backend/src/commands/meetup/commands/create.ts
+++ b/backend/src/commands/meetup/commands/create.ts
@@ -58,10 +58,12 @@ export async function create (message: Message) : Promise<void> {
     timestamp:       DateTime.fromISO (options.date).toISO (),
     description:     options.description || '',
     links:           options.links ?? [],
-    rsvps:           [],
-    maybes:          [],
-    location:        M.location (options),
-    state:           { type: 'Live' }
+    rsvps:           [
+      message.author.id
+    ],
+    maybes:   [],
+    location: M.location (options),
+    state:    { type: 'Live' }
   };
 
   try {
@@ -71,6 +73,8 @@ export async function create (message: Message) : Promise<void> {
       ...meetup,
       announcementID: post.id
     });
+
+    await thread.members.add (message.author.id);
   }
   catch (e) {
     const errId = Math.floor (Math.random () * 1000).toString ();

--- a/backend/src/commands/meetup/features/UpdateRsvps.ts
+++ b/backend/src/commands/meetup/features/UpdateRsvps.ts
@@ -56,7 +56,9 @@ const createRsvpListener = async (client: Discord.Client, meetup: db.Meetup) : P
         maybes: state.maybes.filter (id => id !== i.user.id)
       });
 
-      i.channel && i.channel.send (`✅ <@${i.user.id}> is attending!`);
+      if (i.channel && i.channel.isThread ())
+        i.channel.members.add (i.user.id);
+
       i.deferUpdate ();
     }
     else if (i.customId === 'maybe' && !state.maybes.includes (i.user.id)) {


### PR DESCRIPTION
Closes #122 

Now when you create a meetup, you automatically get RSVP'd and added to the thread.

Also instead of sending a message the bot just uses members.add(), it looks cooler